### PR TITLE
No Obj-C types needed by user any more

### DIFF
--- a/src/libCUserNotification/libCUserNotification.c
+++ b/src/libCUserNotification/libCUserNotification.c
@@ -27,31 +27,37 @@ id init_notification() {
                             sel_registerName("init"));
 }
 
-void set_title(id *notif, char * title) {
+usernotification_t * new_usernotification() {
+    usernotification_t *notif = malloc(sizeof(usernotification_t));
+    notif->notification = init_notification();
+    return notif;
+}
+
+void set_title(usernotification_t *notif, char * title) {
     CFStringRef cf_title = c_cfstr(title);
-    objc_msgSend(*notif, sel_registerName("setTitle:"), cf_title);
+    objc_msgSend(notif->notification, sel_registerName("setTitle:"), cf_title);
     CFRelease(cf_title);
 }
 
-void set_subtitle(id *notif, char * subtitle) {
+void set_subtitle(usernotification_t *notif, char * subtitle) {
     CFStringRef cf_sub = c_cfstr(subtitle);
-    objc_msgSend(*notif, sel_registerName("setSubtitle:"), cf_sub);
+    objc_msgSend(notif->notification, sel_registerName("setSubtitle:"), cf_sub);
     CFRelease(cf_sub);
 }
 
-void set_info_text(id *notif, char * info_text) {
+void set_info_text(usernotification_t *notif, char * info_text) {
     CFStringRef cf_info = c_cfstr(info_text);
-    objc_msgSend(*notif, sel_registerName("setInformativeText:"), cf_info);
+    objc_msgSend(notif->notification, sel_registerName("setInformativeText:"), cf_info);
     CFRelease(cf_info);
 }
 
-void set_sound_name(id *notif, char * sound_name) {
+void set_sound_name(usernotification_t *notif, char * sound_name) {
     CFStringRef cf_sound = c_cfstr(sound_name);
-    objc_msgSend(*notif, sel_registerName("setSoundName:"), cf_sound);
+    objc_msgSend(notif->notification, sel_registerName("setSoundName:"), cf_sound);
     CFRelease(cf_sound);
 }
 
-void post_notification(id *notif) {
+void post_notification(usernotification_t *notif) {
     id pool = (id)objc_getClass("NSAutoreleasePool");
     
     pool = objc_msgSend(pool,
@@ -59,7 +65,7 @@ void post_notification(id *notif) {
                         sel_registerName("init"));
 
     set_bundle_id();
-    objc_msgSend(get_default_user_notif_center(), sel_registerName("deliverNotification:"), *notif);
+    objc_msgSend(get_default_user_notif_center(), sel_registerName("deliverNotification:"), notif->notification);
 
     sleep(1);
     objc_msgSend(pool, sel_registerName("release"));

--- a/src/libCUserNotification/libCUserNotification.h
+++ b/src/libCUserNotification/libCUserNotification.h
@@ -3,12 +3,17 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <objc/objc-runtime.h>
 
-id init_notification();
+typedef struct S_nsusernotification {
+	id notification;
+} usernotification_t;
+
 CFStringRef c_cfstr(char * str);
-void set_title(id *notif, char * title);
-void set_subtitle(id *notif, char * subtitle);
-void set_info_text(id *notif, char * info_text);
-void set_sound_name(id *notif, char * sound_name);
-void post_notification(id *notif);
+id init_notification();
+usernotification_t * new_usernotification();
+void set_title(usernotification_t *notif, char * title);
+void set_subtitle(usernotification_t *notif, char * subtitle);
+void set_info_text(usernotification_t *notif, char * info_text);
+void set_sound_name(usernotification_t *notif, char * sound_name);
+void post_notification(usernotification_t *notif);
 
 #endif

--- a/src/notifier.c
+++ b/src/notifier.c
@@ -32,22 +32,21 @@ void concat_args(char *str, char **argv, uintptr_t *i, uintptr_t argc) {
 
 _Bool send_notification(char * title, char * subtitle, char * info_text, char * sound_name) {
     
-    id notif = init_notification();
-    
-    set_title(&notif, title);
+    usernotification_t *notif = new_usernotification();
+    set_title(notif, title);
     
     if (subtitle) {
-        set_subtitle(&notif, subtitle);
+        set_subtitle(notif, subtitle);
     }
     if (info_text) {
-        set_info_text(&notif, info_text);
+        set_info_text(notif, info_text);
     }
     if (sound_name) {
-        set_sound_name(&notif, sound_name);
+        set_sound_name(notif, sound_name);
     }
 
-    post_notification(&notif);
-
+    post_notification(notif);
+    free(notif);
     return true;
 }
 


### PR DESCRIPTION
New typedef struct that contains an `id` type that is assigned the NSUserNotification. No Obj-C types are needed by user any more